### PR TITLE
Fix files attributes in RPM

### DIFF
--- a/keystone-scim.spec
+++ b/keystone-scim.spec
@@ -39,6 +39,7 @@ cp -a %{_root}/keystone_scim $RPM_BUILD_ROOT/%{python_lib}
 find $RPM_BUILD_ROOT/%{python_lib}/keystone_scim -name "*.pyc" -delete
 
 %files
+%defattr(644,root,root,755)
 %{python_lib}/keystone_scim/*
 
 %post


### PR DESCRIPTION
Added line `%defattr(644,root,root,755)` after `%files` directive to ensure that files has the correct attributes in the RPM