### PR TITLE
Task/allow python 3.6 and 3.9

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+v1.7.0
+------
+Upgrade to allow use with Python 3.6 and Python 3.9
+
 v1.6.0
 ------
 Fix bug retrieving from LDAP which not uses decorete_core_limit and then no scim info in in hints

--- a/keystone-scim.spec
+++ b/keystone-scim.spec
@@ -22,6 +22,9 @@ BuildArch: noarch
 %if 0%{?with_python36}
 %define python_lib /usr/lib/python3.6/site-packages
 %endif # if with_python36
+%if 0%{?with_python39}
+%define python_lib /usr/lib/python3.9/site-packages
+%endif # if with_python39
 
 %define check_paste %(test -e /etc/keystone/keystone-paste.ini && echo 1 || echo 0)
 %if %check_paste

--- a/keystone-scim.spec
+++ b/keystone-scim.spec
@@ -19,6 +19,9 @@ BuildArch: noarch
 %if 0%{?with_python27}
 %define python_lib /usr/lib/python2.7/site-packages
 %endif # if with_python27
+%if 0%{?with_python36}
+%define python_lib /usr/lib/python3.6/site-packages
+%endif # if with_python36
 
 %define check_paste %(test -e /etc/keystone/keystone-paste.ini && echo 1 || echo 0)
 %if %check_paste

--- a/keystone_scim/contrib/scim/core.py
+++ b/keystone_scim/contrib/scim/core.py
@@ -40,10 +40,10 @@ def decorate_core_limit(f):
     def limit_scim_extenstion(query, hints):
         query = f(query, hints)
         total = query.count()
-        try:
-            query = query.order_by(hints.scim_order_by)
-        except AttributeError:
-            pass
+        #try:
+        #  #  query = query.order_by(hints.scim_order_by)
+        #except AttributeError:
+        #    pass
         try:
             query = query.offset(hints.scim_offset)
         except AttributeError:

--- a/keystone_scim/contrib/scim/core.py
+++ b/keystone_scim/contrib/scim/core.py
@@ -40,10 +40,6 @@ def decorate_core_limit(f):
     def limit_scim_extenstion(query, hints):
         query = f(query, hints)
         total = query.count()
-        #try:
-        #  #  query = query.order_by(hints.scim_order_by)
-        #except AttributeError:
-        #    pass
         try:
             query = query.offset(hints.scim_offset)
         except AttributeError:

--- a/keystone_scim/contrib/scim/scim.py
+++ b/keystone_scim/contrib/scim/scim.py
@@ -62,7 +62,7 @@ def pagination(hints=None):
         hints.scim_offset = q['startIndex']
     except KeyError:
         pass
-    hints.scim_order_by = 'name'
+    #hints.scim_order_by = 'name'
     return hints
 
 def get_scim_page_info(hints):

--- a/keystone_scim/contrib/scim/scim.py
+++ b/keystone_scim/contrib/scim/scim.py
@@ -135,6 +135,7 @@ class ScimUserResource(ks_flask.ResourceBase):
         domain = self._get_domain_id_for_list_request()
         refs = PROVIDERS.identity_api.list_users(
             domain_scope=domain, hints=hints)
+        refs.sort(key=lambda d: d['name'])
         scim_page_info = get_scim_page_info(hints)
         # Fix bug retrieving from LDAP which not uses decorete_core_limit and then no scim info in in hints
         if "totalResults" in scim_page_info and scim_page_info['totalResults'] == 0 and len(refs) > 0:
@@ -233,6 +234,7 @@ class ScimRoleResource(ks_flask.ResourceBase):
         ENFORCER.enforce_call(action='identity:list_roles',
                               filters=filters)
         refs = PROVIDERS.role_api.list_roles(hints=pagination(hints))
+        refs.sort(key=lambda d: d['name'])
         scim_page_info = get_scim_page_info(hints)
         # Fix bug retrieving from LDAP which not uses decorete_core_limit and then no scim info in in hints
         if "totalResults" in scim_page_info and scim_page_info['totalResults'] == 0 and len(refs) > 0:
@@ -398,6 +400,7 @@ class ScimGroupResource(ks_flask.ResourceBase):
                               target_attr=target)
         refs = PROVIDERS.identity_api.list_groups(
             domain_scope=domain, hints=hints)
+        refs.sort(key=lambda d: d['name'])
         scim_page_info = get_scim_page_info(hints)
         # Fix bug retrieving from LDAP which not uses decorete_core_limit and then no scim info in in hints
         if "totalResults" in scim_page_info and scim_page_info['totalResults'] == 0 and len(refs) > 0:

--- a/keystone_scim/contrib/scim/scim.py
+++ b/keystone_scim/contrib/scim/scim.py
@@ -62,7 +62,6 @@ def pagination(hints=None):
         hints.scim_offset = q['startIndex']
     except KeyError:
         pass
-    #hints.scim_order_by = 'name'
     return hints
 
 def get_scim_page_info(hints):

--- a/package-keystone-scim.sh
+++ b/package-keystone-scim.sh
@@ -15,6 +15,7 @@ args=("$@")
 ELEMENTS=${#args[@]}
 PYTHON27_VALUE=0
 PYTHON36_VALUE=0
+PYTHON39_VALUE=0
 
 for (( i=0;i<$ELEMENTS;i++)); do
     arg=${args[${i}]}
@@ -23,6 +24,9 @@ for (( i=0;i<$ELEMENTS;i++)); do
     fi
     if [ "$arg" == "--with-python36" ]; then
         PYTHON36_VALUE=1
+    fi
+    if [ "$arg" == "--with-python39" ]; then
+        PYTHON39_VALUE=1
     fi
     if [ "$arg" == "--with-version" ]; then
         VERSION_VALUE=${args[${i}+1]}
@@ -41,4 +45,5 @@ rpmbuild -bb keystone-scim.spec \
   --define "_version $VERSION_VALUE"\
   --define "_release $RELEASE_VALUE"\
   --define "with_python27 $PYTHON27_VALUE"\
-  --define "with_python36 $PYTHON36_VALUE"
+  --define "with_python36 $PYTHON36_VALUE"\
+  --define "with_python39 $PYTHON39_VALUE"

--- a/package-keystone-scim.sh
+++ b/package-keystone-scim.sh
@@ -13,11 +13,16 @@ RELEASE_VALUE=${string#* }
 
 args=("$@")
 ELEMENTS=${#args[@]}
+PYTHON27_VALUE=0
+PYTHON36_VALUE=0
 
 for (( i=0;i<$ELEMENTS;i++)); do
     arg=${args[${i}]}
     if [ "$arg" == "--with-python27" ]; then
         PYTHON27_VALUE=1
+    fi
+    if [ "$arg" == "--with-python36" ]; then
+        PYTHON36_VALUE=1
     fi
     if [ "$arg" == "--with-version" ]; then
         VERSION_VALUE=${args[${i}+1]}
@@ -35,4 +40,5 @@ rpmbuild -bb keystone-scim.spec \
   --define "_root $BASE"\
   --define "_version $VERSION_VALUE"\
   --define "_release $RELEASE_VALUE"\
-  --define "with_python27 $PYTHON27_VALUE"
+  --define "with_python27 $PYTHON27_VALUE"\
+  --define "with_python36 $PYTHON36_VALUE"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,10 @@ classifier =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 2.6
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.9
 
 [files]
 packages =


### PR DESCRIPTION
Allow use this plugin with python36. and python39, needed by latest versions of Keystone